### PR TITLE
changed to new syntax

### DIFF
--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -124,7 +124,7 @@ Once declared, indexes need to be created before being usable.
 When using Rails, you may use the rake task:
 
 {% highlight bash %}
-rake db:update_indexes
+rake nobrainer:update_indexes (previously rake db:update_indexes)
 {% endhighlight %}
 
 You can also update indexes programmatically:


### PR DESCRIPTION
Maybe one should say "< x.x.x db:update_indexes" instead where x.x.x is the version where the syntax was changed, or maybe just skip that thing altogether
